### PR TITLE
add build infos to README.md (fix #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,10 @@ where
  
  ### Requirements:
 * java1.8
-* maven to build (`mvn package`)
+* [maven](https://maven.apache.org/guides/index.html)
+
+### Build:
+Simply run `mvn package` in the project root. All dependencies should be resolved automatically by maven.
 
 ### Issues:
 In case of any issue (for example the program hangs), please report it into the [/ont-converter/issues](https://github.com/sszuev/ont-converter/issues) page, but only if you really sure that the problem is in the program, not in the underlying API. Otherwise please refer to the [/ont-api/issues](https://github.com/avicomp/ont-api/issues) page.


### PR DESCRIPTION
Despite #2 is labeled as `wontfix` I propose this small supplement to the README which might help people which are new to building java packages with maven (like me).